### PR TITLE
Set Github email in database

### DIFF
--- a/src/main/java/se/iths/springbootgroupproject/config/GitHubService.java
+++ b/src/main/java/se/iths/springbootgroupproject/config/GitHubService.java
@@ -22,7 +22,6 @@ public class GitHubService {
 
     @Retryable
     public List<Email> getEmails(OAuth2AccessToken accessToken) {
-        System.out.println("Getting emails from GitHub...");
         return restClient.get()
                 .uri("https://api.github.com/user/emails")
                 .headers(headers -> headers.setBearerAuth(accessToken.getTokenValue()))

--- a/src/main/java/se/iths/springbootgroupproject/config/GithubOAuth2UserService.java
+++ b/src/main/java/se/iths/springbootgroupproject/config/GithubOAuth2UserService.java
@@ -1,8 +1,5 @@
 package se.iths.springbootgroupproject.config;
 
-import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
@@ -28,34 +25,44 @@ public class GithubOAuth2UserService extends DefaultOAuth2UserService {
         this.gitHubService = gitHubService;
     }
 
+
+
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oauth2User = super.loadUser(userRequest);
         Map<String, Object> attributes = oauth2User.getAttributes();
-        Optional<User> authenticatedUser = userRepository.findByGitId((Integer) attributes.get("id"));
+        Integer gitId = (Integer) attributes.get("id");
+        Optional<User> authenticatedUser = userRepository.findByGitId(gitId);
+
         if (authenticatedUser.isEmpty()) {
-            OAuth2AccessToken accessToken = userRequest.getAccessToken();
-            User user = new User();
-            user.setUserName((String) attributes.get("login"));
-            user.setAvatarUrl((String) attributes.get("avatar_url"));
-            user.setFullName((String) attributes.get("name"));
-
-            user.setEmail((String) attributes.get("email"));
-            user.setGitId((Integer) attributes.get("id"));
-            user.setRole("ROLE_USER");
-            List<Email> result = gitHubService.getEmails(accessToken);
-            for (Email email : result) {
-                if (email.primary()) {
-                    String gitHubEmail = email.email();
-                    System.out.println("Primary Email Address: " + gitHubEmail);
-                    user.setEmail(gitHubEmail);
-                    break;
-                }
-            }
+            User user = createUserFromAttributes(attributes, userRequest);
             userRepository.save(user);
-
         }
+
         return oauth2User;
     }
+
+    private User createUserFromAttributes(Map<String, Object> attributes, OAuth2UserRequest userRequest) {
+        OAuth2AccessToken accessToken = userRequest.getAccessToken();
+        User user = new User();
+        user.setUserName((String) attributes.get("login"));
+        user.setAvatarUrl((String) attributes.get("avatar_url"));
+        user.setFullName((String) attributes.get("name"));
+        user.setEmail((String) attributes.get("email"));
+        user.setGitId((Integer) attributes.get("id"));
+        user.setRole("ROLE_USER");
+
+        List<Email> result = gitHubService.getEmails(accessToken);
+        for (Email email : result) {
+            if (email.primary()) {
+                String gitHubEmail = email.email();
+                user.setEmail(gitHubEmail);
+                break;
+            }
+        }
+
+        return user;
+    }
+
 
 }


### PR DESCRIPTION
Now the (primary) GitHub email gets saved in the database when the user is logging in for the first time.